### PR TITLE
Allow multiple service types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.haproxy.cfg
+hadiscover

--- a/etcd.go
+++ b/etcd.go
@@ -1,36 +1,38 @@
 package main
 
-import(
-    "github.com/coreos/go-etcd/etcd"
-    "strings"
-    "fmt"
-    "log"
+import (
+	"fmt"
+	"github.com/coreos/go-etcd/etcd"
+	"log"
+	"strings"
 )
 
-type Backend struct{
-    Name string
-    Ip string
-    Port string
+type Backend struct {
+	Name string
+	Ip   string
+	Port string
 }
 
+func GetBackends(client *etcd.Client, service, backendName string) (map[string][]Backend, error) {
 
-func GetBackends(client *etcd.Client, service, backendName string)([]Backend,error){
+	resp, err := client.Get(service, false, true)
+	if err != nil {
+		log.Println("Error when reading etcd: ", err)
+		return nil, err
+	} else {
+		backends := make(map[string][]Backend)
 
-    resp,err := client.Get(service,false,true)
-    if (err != nil){
-        log.Println("Error when reading etcd: ",err)
-        return nil,err
-    } else{
-        backends := make([]Backend,len(resp.Node.Nodes))
-        for index,element := range resp.Node.Nodes {
+		for index, element := range resp.Node.Nodes {
 
-            key := (*element).Key // key format is: /service/IP:PORT
-            service := strings.Split(key[strings.LastIndex(key,"/")+1:],":")
+			key := (*element).Key // key format is: /service/IP:PORT
+			service := strings.Split(key[strings.LastIndex(key, "/")+1:], ":")
+			serviceType := (*element).Value
 
-            backends[index] = Backend{Name: fmt.Sprintf("back-%v",index), Ip: service[0], Port: service[1]}
-        }
-        return backends,nil
-    }
+			backend := Backend{Name: fmt.Sprintf("back-%v", index), Ip: service[0], Port: service[1]}
+
+			backends[serviceType] = append(backends[serviceType], backend)
+		}
+		return backends, nil
+	}
 
 }
-

--- a/hadiscover.go
+++ b/hadiscover.go
@@ -8,14 +8,14 @@ import (
 
 var filename = flag.String("config","./haproxy.cfg.tpl","Template config file used for HAproxy")
 var name     = flag.String("name","back","Base name used for backends")
-var haproxy  = flag.String("ha","/usr/bin/haproxy","Path to the `haproxy` executable")
+var haproxy  = flag.String("ha","/usr/local/bin/haproxy","Path to the `haproxy` executable")
 var etcdHost = flag.String("etcd","http://localhost:4001","etcd server(s)")
 var etcdKey  = flag.String("key","services","etcd root key to look for")
 
 var configFile = ".haproxy.cfg"
 
-func reloadConf(etcdClient *etcd.Client)(error){
-    backends,_ := GetBackends(etcdClient,*etcdKey,*name)
+func reloadConf(etcdClient *etcd.Client)(error) {
+    backends, _ := GetBackends(etcdClient, *etcdKey, *name)
 
     err := createConfigFile(backends, *filename, configFile)
     if(err != nil){
@@ -25,7 +25,7 @@ func reloadConf(etcdClient *etcd.Client)(error){
     return reloadHAproxy(*haproxy, configFile)
 }
 
-func main(){
+func main() {
     flag.Parse()
 
     var etcdClient = etcd.NewClient([]string{*etcdHost})
@@ -43,15 +43,15 @@ func main(){
             if (reload){
                 err := reloadConf(etcdClient)
                 if(err != nil){
-                    log.Println("Cannot reload haproxy: ",err,msg)
+                    log.Println("Cannot reload haproxy: ", err, msg)
                 }
             }
         }
     }()
 
     log.Println("Start watching changes in etcd")
-    if _, err := etcdClient.Watch(*etcdKey,0, true, changeChan, stopChan) ; err != nil{
-        log.Println("Cannot register watcher for changes in etcd: ",err)
+    if _, err := etcdClient.Watch(*etcdKey, 0, true, changeChan, stopChan) ; err != nil{
+        log.Println("Cannot register watcher for changes in etcd: ", err)
     }    
 
 }

--- a/haproxy.cfg.tpl
+++ b/haproxy.cfg.tpl
@@ -1,0 +1,36 @@
+global
+    maxconn 4096
+    daemon
+
+defaults
+    log global
+    mode    http
+    option  httplog
+    option  dontlognull
+    retries 3
+    redispatch
+    maxconn 2000
+    contimeout  5000
+    clitimeout  50000
+    srvtimeout  50000
+    option httpclose
+    option forceclose
+    option http-pretend-keepalive
+
+frontend public
+    bind *:8000
+
+    acl is_api_domain hdr_beg(host) -i api.
+    http-request deny unless is_api_domain
+    {{range $serviceName, $servers := .}}{{if not (eq $serviceName "bootstrap")}}
+    acl is_{{$serviceName}} path_beg /{{$serviceName}}
+    use_backend {{$serviceName}} if is_{{$serviceName}}
+    {{end}}{{end}}
+    default_backend bootstrap
+
+{{range $serviceName, $servers := .}}
+backend {{$serviceName}}
+    {{range .}}
+    server {{.Name}} {{.Ip}}:{{.Port}} check
+    {{end}}
+{{end}}

--- a/haproxy.go
+++ b/haproxy.go
@@ -1,46 +1,46 @@
 package main
 
-import(
-    "text/template"
-    "os"
-    "os/exec"
-    "log"
-    "strconv"
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"text/template"
 )
 
 var tpl *template.Template = nil
 var pid int = -1
 
-func createConfigFile(backends []Backend, templateFile, outputFile string)(error){
-    cfgFile,_ := os.Create(outputFile)
-    defer cfgFile.Close()
+func createConfigFile(backends map[string][]Backend, templateFile, outputFile string) error {
+	cfgFile, _ := os.Create(outputFile)
+	defer cfgFile.Close()
 
-    if(tpl == nil){
-        var err error = nil
-        tpl, err = template.ParseFiles(templateFile)
-        if (err != nil){
-            return err
-        }
-    }
-    
-    return tpl.Execute(cfgFile, backends)
+	if tpl == nil {
+		var err error = nil
+		tpl, err = template.ParseFiles(templateFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	return tpl.Execute(cfgFile, backends)
 }
 
-func reloadHAproxy(command, configFile string)(error){
-    var cmd *exec.Cmd = nil
-    if pid == -1{
-        log.Println("Start HAproxy")
-        cmd = exec.Command(command,"-f",configFile)
-        go cmd.Wait()
-    } else{
-        log.Println("Restart HAproxy")
-        cmd = exec.Command(command,"-f",configFile,"-sf",strconv.Itoa(pid))
-    }
-    
-    err := cmd.Start()
-    if (err == nil){
-        pid = cmd.Process.Pid
-        log.Println("New pid: ",pid)
-    }
-    return err
+func reloadHAproxy(command, configFile string) error {
+	var cmd *exec.Cmd = nil
+	if pid == -1 {
+		log.Println("Start HAproxy")
+		cmd = exec.Command(command, "-f", configFile)
+		go cmd.Wait()
+	} else {
+		log.Println("Restart HAproxy")
+		cmd = exec.Command(command, "-f", configFile, "-sf", strconv.Itoa(pid))
+	}
+
+	err := cmd.Start()
+	if err == nil {
+		pid = cmd.Process.Pid
+		log.Println("New pid: ", pid)
+	}
+	return err
 }


### PR DESCRIPTION
### New Feature

Now expects the value of the key written to etcd to be a service name, which gets its own backend in the HAProxy config, and has requests of that path routed to it.
